### PR TITLE
feat: add Go solution, tests, & readme for LC0011

### DIFF
--- a/go/0011/README.md
+++ b/go/0011/README.md
@@ -1,0 +1,39 @@
+# Container With Most Water
+
+You are given an integer array height of length n. There are n vertical lines
+drawn such that the two endpoints of the ith line are (i, 0) and (i,
+height[i]).
+
+Find two lines that together with the x-axis form a container, such that the
+container contains the most water.
+
+Return the maximum amount of water a container can store.
+
+Notice that you may not slant the container.
+
+## Example 1
+
+![Bar Chart](https://s3-lc-upload.s3.amazonaws.com/uploads/2018/07/17/question_11.jpg)
+
+```text
+Input: height = [1,8,6,2,5,4,8,3,7]
+Output: 49
+Explanation: The above vertical lines are represented by array
+[1,8,6,2,5,4,8,3,7]. In this case, the max area of water (blue section) the
+container can contain is 49.
+```
+
+## Example 2
+
+```text
+Input: height = [1,1]
+Output: 1
+```
+
+## Constraints
+
+```text
+n == height.length
+2 <= n <= 105
+0 <= height[i] <= 104
+```

--- a/go/0011/solution.go
+++ b/go/0011/solution.go
@@ -1,0 +1,30 @@
+package problem0011
+
+func maxArea(height []int) int {
+	max, left, right := 0, 0, len(height)-1
+
+	for left < right {
+		currArea := getArea(left, right, height)
+		if currArea > max {
+			max = currArea
+		}
+		if height[left] < height[right] {
+			left++
+		} else {
+			right--
+		}
+	}
+
+	return max
+}
+
+func getArea(left, right int, arr []int) int {
+	width := right - left
+	height := 0
+	if arr[left] < arr[right] {
+		height = arr[left]
+	} else {
+		height = arr[right]
+	}
+	return width * height
+}

--- a/go/0011/solution_test.go
+++ b/go/0011/solution_test.go
@@ -1,0 +1,26 @@
+package problem0011
+
+import "testing"
+
+func TestMaxArea(t *testing.T) {
+	testcases := []struct {
+		height []int
+		want   int
+	}{
+		{
+			height: []int{1, 8, 6, 2, 5, 4, 8, 3, 7},
+			want:   49,
+		},
+		{
+			height: []int{1, 1},
+			want:   1,
+		},
+	}
+
+	for _, tc := range testcases {
+		result := maxArea(tc.height)
+		if result != tc.want {
+			t.Errorf("maxArea: %v, want: %v\n", result, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
# Overview
- Added README, solution, and tests for leetcode #0011

# Solution
- created getArea helper function to determine max area given two indices
- left and right pointers start at opposite ends of height arr
- while left is less than right calculate current area
- if current area is greater than stored area, replace it
- if left is less than right, increment left. 
- else increment right