### PR TITLE
fix: correctly navigate to typescript directory

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,8 +12,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Navigation
-        uses: cd typescript
+      - name: Navigation to typescript directory
+        run: cd typescript
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1


### PR DESCRIPTION
# Overview
- fixed but causing github actions to fail

# Changes
- Utilized "run" command instead of "use" command to change directory